### PR TITLE
refactor: migrate from @import to @use for SCSS files

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,6 @@
         "invariant": "^2.2.4",
         "lodash": "^4.17.21",
         "moment": "^2.30.1",
-        "normalize-scss": "^8.0.0",
         "prism-react-renderer": "^2.4.1",
         "prismjs": "^1.30.0",
         "react": "^18.3.1",
@@ -19016,12 +19015,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/normalize-scss": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/normalize-scss/-/normalize-scss-8.0.0.tgz",
-      "integrity": "sha512-C6GXIxQ2LOYWrde27xWbONavmybobxp+V6TY8BiBJw5M+yMNEg2R0WjaeDtmP5JsunFYKvFOvgMAIC0/OxZuJQ==",
-      "license": "(MIT OR GPL-2.0)"
     },
     "node_modules/normalize-url": {
       "version": "6.1.0",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
     "invariant": "^2.2.4",
     "lodash": "^4.17.21",
     "moment": "^2.30.1",
-    "normalize-scss": "^8.0.0",
     "prism-react-renderer": "^2.4.1",
     "prismjs": "^1.30.0",
     "react": "^18.3.1",

--- a/src/assets/scss/_base.scss
+++ b/src/assets/scss/_base.scss
@@ -1,4 +1,3 @@
 @charset "UTF-8";
 
-@import "normalize-scss";
-@import "base/generic";
+@use "base/generic";

--- a/src/assets/scss/init.scss
+++ b/src/assets/scss/init.scss
@@ -1,4 +1,4 @@
 @charset "UTF-8";
 
-@import 'variables';
-@import 'base';
+@use 'variables';
+@use 'base';

--- a/src/components/Layout/Image.js
+++ b/src/components/Layout/Image.js
@@ -3,7 +3,7 @@ import { Frame, TitleBar } from '@react95/core';
 import { Wangimg128 } from '@react95/icons';
 
 const GGImage = (props) => {
-  const { src, alt, title = '' } = props;
+  const { src, alt, title = `${alt.replace(/\s+/g, '_')}.png` } = props;
 
   const [description, width] = title.split('|').map((s) => s.trim());
 


### PR DESCRIPTION

<img width="303" height="270" alt="image" src="https://github.com/user-attachments/assets/58be13bf-5b82-42a2-8e0f-08bba0e64a1e" />


This pull request primarily updates how SCSS modules are imported and used throughout the codebase, transitioning from the deprecated `@import` syntax to the modern `@use` syntax. Additionally, it removes the `normalize-scss` dependency, and improves the default behavior of the `title` prop in the `GGImage` component.

**SCSS Modernization and Dependency Cleanup:**

* Replaced all `@import` statements with `@use` in SCSS files (`_base.scss`, `init.scss`), which is the recommended approach in recent versions of Sass. [[1]](diffhunk://#diff-ecf64c715d24af8397490b5c5b5c9b5378444b693327392052cbbfbeee83807cL3-R3) [[2]](diffhunk://#diff-0125611283a355453fbafb28a722efda32b627d17d6896e9ff8d06f70bcedc5fL3-R4)
* Removed the `normalize-scss` dependency from `package.json` and its usage in SCSS, simplifying the dependency tree. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L63) [[2]](diffhunk://#diff-ecf64c715d24af8397490b5c5b5c9b5378444b693327392052cbbfbeee83807cL3-R3)

**Component Enhancement:**

* Updated the `GGImage` component in `Image.js` so the `title` prop now defaults to a filename-style string based on the `alt` text if not explicitly provided, improving accessibility and consistency.