### PR TITLE
Integrate reading time estimation and display across blog components

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -151,6 +151,14 @@ module.exports = {
         ],
       },
     },
+    {
+      resolve: 'gatsby-plugin-readingtime',
+      options: {
+        types: {
+          MarkdownRemark: (source) => source.rawMarkdownBody,
+        },
+      },
+    },
     'gatsby-transformer-sharp',
     'gatsby-plugin-sharp',
     {

--- a/locales/en/translation.json
+++ b/locales/en/translation.json
@@ -1,6 +1,8 @@
 {
   "Read": "Read",
   "Published": "Published",
+  "min read_one": "{{count}} min read",
+  "min read_other": "{{count}} min read",
   "All posts": "All posts",
   "Not found": "NOT FOUND",
   "< PREV": "< PREV",

--- a/locales/pt/translation.json
+++ b/locales/pt/translation.json
@@ -1,6 +1,8 @@
 {
   "Read": "Ler",
   "Published": "Publicado",
+  "min read_one": "{{count}} min de leitura",
+  "min read_other": "{{count}} min de leitura",
   "All posts": "Todos os artigos",
   "Not found": "PAGINA NAO ENCONTRADA",
   "< PREV": "< ANTERIOR",

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "gatsby-plugin-manifest": "^5.15.0",
         "gatsby-plugin-offline": "^6.15.0",
         "gatsby-plugin-react-i18next": "^3.0.1",
+        "gatsby-plugin-readingtime": "^3.0.2",
         "gatsby-plugin-sass": "^6.15.0",
         "gatsby-plugin-sharp": "^5.15.0",
         "gatsby-plugin-sitemap": "^6.15.0",
@@ -4654,6 +4655,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.7.tgz",
       "integrity": "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -11090,6 +11092,18 @@
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
       "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
       "license": "MIT"
+    },
+    "node_modules/gatsby-plugin-readingtime": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-readingtime/-/gatsby-plugin-readingtime-3.0.2.tgz",
+      "integrity": "sha512-lDjcK76yU3k8t3zEZ72Z5+fMFwTuhJEqQTIJooSnKF+mNmjcm3YAFm/r2Z23ioXVBQKgu+il+SZ0+9eHUc+Kvw==",
+      "license": "MIT",
+      "dependencies": {
+        "reading-time": "^1.5.0"
+      },
+      "peerDependencies": {
+        "gatsby": "^4.0.0 || ^5.0.0"
+      }
     },
     "node_modules/gatsby-plugin-sass": {
       "version": "6.15.0",
@@ -18743,6 +18757,12 @@
       "engines": {
         "node": ">=8.10.0"
       }
+    },
+    "node_modules/reading-time": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/reading-time/-/reading-time-1.5.0.tgz",
+      "integrity": "sha512-onYyVhBNr4CmAxFsKS7bz+uTLRakypIe4R+5A824vBSkQy/hB3fZepoVEf8OVAxzLvK+H/jm9TzpI3ETSm64Kg==",
+      "license": "MIT"
     },
     "node_modules/recursive-readdir": {
       "version": "2.2.3",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "gatsby-plugin-manifest": "^5.15.0",
     "gatsby-plugin-offline": "^6.15.0",
     "gatsby-plugin-react-i18next": "^3.0.1",
+    "gatsby-plugin-readingtime": "^3.0.2",
     "gatsby-plugin-sass": "^6.15.0",
     "gatsby-plugin-sharp": "^5.15.0",
     "gatsby-plugin-sitemap": "^6.15.0",

--- a/src/assets/scss/_variables.scss
+++ b/src/assets/scss/_variables.scss
@@ -32,6 +32,7 @@
   --typographic-root-font-size: 14px;
   --typographic-base-font-size: 14px;
   --typographic-small-font-size: 12px;
+  --typographic-tiny-font-size: 10px;
 
   --typographic-base-line-height: 1.625;
 

--- a/src/components/Feed/Feed.js
+++ b/src/components/Feed/Feed.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Link } from 'gatsby';
 import { useTranslation } from 'gatsby-plugin-react-i18next';
-import { formatLocalizedDate } from '../../utils';
+import { formatLocalizedDate, getReadingTimeMinutes } from '../../utils';
 import * as styles from './Feed.module.scss';
 
 const Feed = ({ edges }) => {
@@ -12,7 +12,7 @@ const Feed = ({ edges }) => {
     <div>
       {edges.map((edge) => (
         <div className={styles['feed__item']} key={edge.node.fields.slug}>
-          <div>
+          <div className={styles['feed__itemMeta']}>
             <time
               className={styles['feed__itemMetaTime']}
               dateTime={formatLocalizedDate(
@@ -27,6 +27,12 @@ const Feed = ({ edges }) => {
                 language,
               )}
             </time>
+            {getReadingTimeMinutes(edge.node.readingTime) ? (
+              <span className={styles['feed__itemMetaReadingTime']}>
+                {' '}
+                • {t('min read', { count: getReadingTimeMinutes(edge.node.readingTime) })}
+              </span>
+            ) : null}
           </div>
           <h2 className={styles['feed__itemTitle']}>
             <Link

--- a/src/components/Feed/Feed.module.scss
+++ b/src/components/Feed/Feed.module.scss
@@ -30,8 +30,17 @@
     }
 
     &-meta {
+      margin-bottom: calc(var(--typographic-leading) * 0.25);
+
       &-time {
         font-size: var(--typographic-small-font-size);
+        color: var(--color-secondary);
+        font-weight: 600;
+        text-transform: uppercase;
+      }
+
+      &-reading-time {
+        font-size: var(--typographic-tiny-font-size);
         color: var(--color-secondary);
         font-weight: 600;
         text-transform: uppercase;

--- a/src/components/Post/Content/Content.js
+++ b/src/components/Post/Content/Content.js
@@ -1,15 +1,27 @@
 import React from 'react';
+import { useTranslation } from 'gatsby-plugin-react-i18next';
+import { getReadingTimeMinutes } from '../../../utils';
 import HtmlContent from './HtmlContent';
 
 import * as styles from './Content.module.scss';
 
-const Content = ({ body, title }) => (
-  <div className={styles['content']}>
-    <h1 className={styles['content__title']}>{title}</h1>
-    <div className={styles['content__body']}>
-      <HtmlContent html={body} />
+const Content = ({ body, title, readingTime }) => {
+  const { t } = useTranslation();
+  const readingTimeMinutes = getReadingTimeMinutes(readingTime);
+
+  return (
+    <div className={styles['content']}>
+      <h1 className={styles['content__title']}>{title}</h1>
+      {readingTimeMinutes ? (
+        <p className={styles['content__readingTime']}>
+          {t('min read', { count: readingTimeMinutes })}
+        </p>
+      ) : null}
+      <div className={styles['content__body']}>
+        <HtmlContent html={body} />
+      </div>
     </div>
-  </div>
-);
+  );
+};
 
 export default Content;

--- a/src/components/Post/Content/Content.module.scss
+++ b/src/components/Post/Content/Content.module.scss
@@ -15,6 +15,17 @@
     margin-bottom: 0;
   }
 
+  &__reading-time {
+    max-width: var(--layout-post-width);
+    margin: calc(var(--typographic-leading) * 0.25) auto
+      calc(var(--typographic-leading) * 1.25);
+    font-size: var(--typographic-small-font-size);
+    color: var(--color-gray);
+    font-weight: 600;
+    text-align: center;
+    text-transform: uppercase;
+  }
+
   &__body {
     & figure,
     & .figure {
@@ -67,6 +78,11 @@
       font-size: calc(var(--typographic-base-font-size) * 3);
       line-height: calc(2.25 * var(--typographic-leading));
       margin-top: calc(var(--typographic-leading) * 2.25);
+      margin-bottom: 0;
+    }
+
+    &__reading-time {
+      margin-top: calc(var(--typographic-leading) * 0.25);
       margin-bottom: calc(var(--typographic-leading) * 1.5);
     }
 

--- a/src/components/Post/Post.js
+++ b/src/components/Post/Post.js
@@ -11,6 +11,7 @@ const Post = ({ post, html }) => {
   const { t } = useTranslation();
   const { slug } = post.fields || {};
   const { title, date } = post.frontmatter;
+  const { readingTime } = post;
 
   return (
     <div className={styles['post']}>
@@ -19,7 +20,7 @@ const Post = ({ post, html }) => {
       </Link>
 
       <div>
-        <Content title={title} body={html} />
+        <Content title={title} body={html} readingTime={readingTime} />
       </div>
 
       <div className={styles['post__footer']}>

--- a/src/templates/index-template.js
+++ b/src/templates/index-template.js
@@ -80,6 +80,9 @@ export const query = graphql`
     ) {
       edges {
         node {
+          readingTime {
+            minutes
+          }
           fields {
             slug
           }

--- a/src/templates/post-template.js
+++ b/src/templates/post-template.js
@@ -47,6 +47,9 @@ export const query = graphql`
     markdownRemark(id: { eq: $id }) {
       id
       html
+      readingTime {
+        minutes
+      }
       fields {
         slug
       }

--- a/src/utils/get-reading-time-minutes.js
+++ b/src/utils/get-reading-time-minutes.js
@@ -1,0 +1,9 @@
+const getReadingTimeMinutes = (readingTime) => {
+  if (!readingTime?.minutes) {
+    return null;
+  }
+
+  return Math.max(1, Math.ceil(readingTime.minutes));
+};
+
+export default getReadingTimeMinutes;

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -2,6 +2,7 @@ export { default as buildDocumentTitle } from './build-document-title';
 export { default as getIcon } from './get-icon';
 export { default as getContactHref } from './get-contact-href';
 export { formatLocalizedDate } from './date';
+export { default as getReadingTimeMinutes } from './get-reading-time-minutes';
 export {
   buildLocalizedPageLookup,
   getLocalizedMenu,


### PR DESCRIPTION
This pull request adds reading time estimates to blog posts and post listings, with localization support and corresponding UI updates. It introduces the `gatsby-plugin-readingtime` plugin, updates GraphQL queries to fetch reading time, and enhances both English and Portuguese translations. Styling and utility functions are also added to support the new feature.

**Feature: Reading Time Estimates**
- Integrated `gatsby-plugin-readingtime` into `gatsby-config.js` and updated dependencies in `package.json` to enable automatic reading time calculation for Markdown files. [[1]](diffhunk://#diff-b5e305780d9d473da97c61beab8bc36e5e8871b360942e4686c9b20d8c5d4cfaR154-R161) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R44)
- Updated GraphQL queries in `index-template.js` and `post-template.js` to fetch `readingTime.minutes` for each post. [[1]](diffhunk://#diff-ef1509b30f9fb2f99d429a4d0fe2114a5ae6ece0415b5862eaf087dfe4f44244R83-R85) [[2]](diffhunk://#diff-bb0860aa4e56f09cae46622c722b44c966001686a484fe928438b673c95eb4adR50-R52)
- Added a new utility function `getReadingTimeMinutes` in `src/utils/get-reading-time-minutes.js` and exported it via `src/utils/index.js` for consistent reading time rounding and minimum enforcement. [[1]](diffhunk://#diff-2b849749245114fa2f1b2ac452507fdaf9a023bc2ead5ebd195b166e92fecbb3R1-R9) [[2]](diffhunk://#diff-ebd8554ec43b07366bd40d16b09d1d063d9e8d5921fa30de4eb80bffdf82668dR5)

**UI and Styling Enhancements**
- Modified `Feed` and `Content` components to display reading time estimates, including conditional rendering and translation. Adjusted their respective SCSS modules to style the new reading time UI elements. [[1]](diffhunk://#diff-ce8f7cba11d193960055970d4acb111664a5c3a04730f341c595bda88d16f639L4-R4) [[2]](diffhunk://#diff-ce8f7cba11d193960055970d4acb111664a5c3a04730f341c595bda88d16f639L15-R15) [[3]](diffhunk://#diff-ce8f7cba11d193960055970d4acb111664a5c3a04730f341c595bda88d16f639R30-R35) [[4]](diffhunk://#diff-a64e22361531ee1264d6337b10b1b94dd1fbdc057676bcd71c44cdedf63e60c2R33-R47) [[5]](diffhunk://#diff-edecc5c9797fe18b557b676ca76a7d2baffd9c473b8a41490068781a8b153f1dR2-R25) [[6]](diffhunk://#diff-781300b14a01dbd6b05ba6173ce6684682efdc08814d8ca923d8bb9749cd00b1R18-R28) [[7]](diffhunk://#diff-781300b14a01dbd6b05ba6173ce6684682efdc08814d8ca923d8bb9749cd00b1R81-R85) [[8]](diffhunk://#diff-e6e0c6e5e6dd01fb7bdda4f56c87456888d95afd2d82765b5b9deb351f893cd9R14) [[9]](diffhunk://#diff-e6e0c6e5e6dd01fb7bdda4f56c87456888d95afd2d82765b5b9deb351f893cd9L22-R23)
- Added a new CSS variable `--typographic-tiny-font-size` for fine-tuned typography in reading time labels.

**Localization**
- Enhanced English and Portuguese translation files to include pluralized strings for reading time, ensuring the feature is fully localized. [[1]](diffhunk://#diff-64ebf44154b7db38cb1577c4258b22fa06ff7373f63c0a2a8e97839bf4f1bcacR4-R5) [[2]](diffhunk://#diff-91d0c546bc166daf8bd6061f0daa8854b071820f83f62ba8638097145a488af1R4-R5)

### Screenshots

| Feed | Post |
|--------|--------|
| <img width="658" height="217" alt="image" src="https://github.com/user-attachments/assets/ad0cb60f-9681-4d59-a6e8-76a96ec44078" /> | <img width="746" height="307" alt="image" src="https://github.com/user-attachments/assets/42313338-513f-4900-ae7d-6bb1f3fb533a" /> | 